### PR TITLE
VCST-4492: Update workflow versions

### DIFF
--- a/.github/workflows/build-and-publish-image.yml
+++ b/.github/workflows/build-and-publish-image.yml
@@ -118,7 +118,7 @@ jobs:
 
   trivy-scan:
     needs: 'ci'
-    uses: VirtoCommerce/.github/.github/workflows/docker-image-vulnerability-process.yml@v3.800.33
+    uses: VirtoCommerce/.github/.github/workflows/docker-image-vulnerability-process.yml@v3.800.38
     with:
       assigneeAccountId: '621c47c0302c6b006af0a1cd'
       assigneeEmailAddress: 'andrew.kubyshkin@virtoworks.com'
@@ -135,7 +135,7 @@ jobs:
 
   auto-tests:
     needs: ci
-    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@VCST-4492 #v3.800.37
+    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.38
     with:
       installModules: 'false'
       installCustomModule: 'false'
@@ -150,41 +150,41 @@ jobs:
       testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE }}
       sendgridApiKey: ${{ secrets.SENDGRID_APIKEY_4E2E_AUTOTESTS }}
 
-  # push-docker-image:
-  #   runs-on: ubuntu-latest
-  #   needs:
-  #   - ci
-  #   - trivy-scan
-  #   - auto-tests
-  #   steps:
-  #   - name: Download Docker image tarball
-  #     uses: actions/download-artifact@v7
-  #     with:
-  #       name: 'image-4test'
+  push-docker-image:
+    runs-on: ubuntu-latest
+    needs:
+    - ci
+    - trivy-scan
+    - auto-tests
+    steps:
+    - name: Download Docker image tarball
+      uses: actions/download-artifact@v7
+      with:
+        name: 'image-4test'
 
-  #   - name: Load Docker image
-  #     run: docker load -i $TAG.tar
-  #     env:
-  #       TAG: ${{ needs.ci.outputs.BUNDLE_VERSION }}-stable
+    - name: Load Docker image
+      run: docker load -i $TAG.tar
+      env:
+        TAG: ${{ needs.ci.outputs.BUNDLE_VERSION }}-stable
 
-  #   - name: Log in to Docker Registry
-  #     uses: docker/login-action@v3
-  #     with:
-  #       registry: virtopaasregistrymain.azurecr.io
-  #       username: saas-token
-  #       password: ${{ secrets.MAIN_DOCKER_PASSWORD }}
+    - name: Log in to Docker Registry
+      uses: docker/login-action@v3
+      with:
+        registry: virtopaasregistrymain.azurecr.io
+        username: saas-token
+        password: ${{ secrets.MAIN_DOCKER_PASSWORD }}
 
-  #   - name: Push Docker image
-  #     run: |
-  #       docker tag local-platform:$TAG $IMAGE_REPOSITORY:$TAG
-  #       docker tag local-platform:$TAG $IMAGE_REPOSITORY:$LATEST_TAG
-  #       docker push $IMAGE_REPOSITORY:$TAG
-  #       docker push $IMAGE_REPOSITORY:$LATEST_TAG
-  #     env:
-  #       DOCKER_LOGIN: VirtoPaaSRegistryMain
-  #       DOCKER_PASSWORD: ${{ secrets.MAIN_DOCKER_PASSWORD }}
-  #       DOCKERFILE_PATH: ./Dockerfile
-  #       CONTAINER_REGISTRY: virtopaasregistrymain.azurecr.io
-  #       IMAGE_REPOSITORY: virtopaasregistrymain.azurecr.io/saas/platform
-  #       TAG: ${{ needs.ci.outputs.BUNDLE_VERSION }}-stable
-  #       LATEST_TAG: latest-stable
+    - name: Push Docker image
+      run: |
+        docker tag local-platform:$TAG $IMAGE_REPOSITORY:$TAG
+        docker tag local-platform:$TAG $IMAGE_REPOSITORY:$LATEST_TAG
+        docker push $IMAGE_REPOSITORY:$TAG
+        docker push $IMAGE_REPOSITORY:$LATEST_TAG
+      env:
+        DOCKER_LOGIN: VirtoPaaSRegistryMain
+        DOCKER_PASSWORD: ${{ secrets.MAIN_DOCKER_PASSWORD }}
+        DOCKERFILE_PATH: ./Dockerfile
+        CONTAINER_REGISTRY: virtopaasregistrymain.azurecr.io
+        IMAGE_REPOSITORY: virtopaasregistrymain.azurecr.io/saas/platform
+        TAG: ${{ needs.ci.outputs.BUNDLE_VERSION }}-stable
+        LATEST_TAG: latest-stable

--- a/.github/workflows/build-and-publish-image.yml
+++ b/.github/workflows/build-and-publish-image.yml
@@ -135,7 +135,7 @@ jobs:
 
   auto-tests:
     needs: ci
-    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.37
+    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@VCST-4492 #v3.800.37
     with:
       installModules: 'false'
       installCustomModule: 'false'
@@ -150,41 +150,41 @@ jobs:
       testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE }}
       sendgridApiKey: ${{ secrets.SENDGRID_APIKEY_4E2E_AUTOTESTS }}
 
-  push-docker-image:
-    runs-on: ubuntu-latest
-    needs:
-    - ci
-    - trivy-scan
-    - auto-tests
-    steps:
-    - name: Download Docker image tarball
-      uses: actions/download-artifact@v7
-      with:
-        name: 'image-4test'
+  # push-docker-image:
+  #   runs-on: ubuntu-latest
+  #   needs:
+  #   - ci
+  #   - trivy-scan
+  #   - auto-tests
+  #   steps:
+  #   - name: Download Docker image tarball
+  #     uses: actions/download-artifact@v7
+  #     with:
+  #       name: 'image-4test'
 
-    - name: Load Docker image
-      run: docker load -i $TAG.tar
-      env:
-        TAG: ${{ needs.ci.outputs.BUNDLE_VERSION }}-stable
+  #   - name: Load Docker image
+  #     run: docker load -i $TAG.tar
+  #     env:
+  #       TAG: ${{ needs.ci.outputs.BUNDLE_VERSION }}-stable
 
-    - name: Log in to Docker Registry
-      uses: docker/login-action@v3
-      with:
-        registry: virtopaasregistrymain.azurecr.io
-        username: saas-token
-        password: ${{ secrets.MAIN_DOCKER_PASSWORD }}
+  #   - name: Log in to Docker Registry
+  #     uses: docker/login-action@v3
+  #     with:
+  #       registry: virtopaasregistrymain.azurecr.io
+  #       username: saas-token
+  #       password: ${{ secrets.MAIN_DOCKER_PASSWORD }}
 
-    - name: Push Docker image
-      run: |
-        docker tag local-platform:$TAG $IMAGE_REPOSITORY:$TAG
-        docker tag local-platform:$TAG $IMAGE_REPOSITORY:$LATEST_TAG
-        docker push $IMAGE_REPOSITORY:$TAG
-        docker push $IMAGE_REPOSITORY:$LATEST_TAG
-      env:
-        DOCKER_LOGIN: VirtoPaaSRegistryMain
-        DOCKER_PASSWORD: ${{ secrets.MAIN_DOCKER_PASSWORD }}
-        DOCKERFILE_PATH: ./Dockerfile
-        CONTAINER_REGISTRY: virtopaasregistrymain.azurecr.io
-        IMAGE_REPOSITORY: virtopaasregistrymain.azurecr.io/saas/platform
-        TAG: ${{ needs.ci.outputs.BUNDLE_VERSION }}-stable
-        LATEST_TAG: latest-stable
+  #   - name: Push Docker image
+  #     run: |
+  #       docker tag local-platform:$TAG $IMAGE_REPOSITORY:$TAG
+  #       docker tag local-platform:$TAG $IMAGE_REPOSITORY:$LATEST_TAG
+  #       docker push $IMAGE_REPOSITORY:$TAG
+  #       docker push $IMAGE_REPOSITORY:$LATEST_TAG
+  #     env:
+  #       DOCKER_LOGIN: VirtoPaaSRegistryMain
+  #       DOCKER_PASSWORD: ${{ secrets.MAIN_DOCKER_PASSWORD }}
+  #       DOCKERFILE_PATH: ./Dockerfile
+  #       CONTAINER_REGISTRY: virtopaasregistrymain.azurecr.io
+  #       IMAGE_REPOSITORY: virtopaasregistrymain.azurecr.io/saas/platform
+  #       TAG: ${{ needs.ci.outputs.BUNDLE_VERSION }}-stable
+  #       LATEST_TAG: latest-stable

--- a/bundles/latest/package.json
+++ b/bundles/latest/package.json
@@ -5,7 +5,7 @@
   "PlatformImage": "ghcr.io/virtocommerce/platform",
   "PlatformImageTag": "3.1007.14",
   "PlatformAssetUrl": "",
-  "BundleVersion": "14.0.33",
+  "BundleVersion": "14.0.34",
   "Sources": [
     {
       "Name": "AzureBlob",

--- a/bundles/latest/package.json
+++ b/bundles/latest/package.json
@@ -5,7 +5,7 @@
   "PlatformImage": "ghcr.io/virtocommerce/platform",
   "PlatformImageTag": "3.1007.15",
   "PlatformAssetUrl": "",
-  "BundleVersion": "14.0.35",
+  "BundleVersion": "14.0.34",
   "Sources": [
     {
       "Name": "AzureBlob",

--- a/bundles/latest/package.json
+++ b/bundles/latest/package.json
@@ -5,7 +5,7 @@
   "PlatformImage": "ghcr.io/virtocommerce/platform",
   "PlatformImageTag": "3.1007.15",
   "PlatformAssetUrl": "",
-  "BundleVersion": "14.0.34",
+  "BundleVersion": "14.0.35",
   "Sources": [
     {
       "Name": "AzureBlob",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version-only changes to CI workflow references with no application or runtime logic modified.
> 
> **Overview**
> Bumps the **Stable platform** workflow (`build-and-publish-image.yml`) to newer shared workflow releases from `VirtoCommerce/.github`.
> 
> The **trivy-scan** job now calls `docker-image-vulnerability-process.yml` at **v3.800.38** (was v3.800.33). The **auto-tests** job now calls `pytest-tests.yml` at **v3.800.38** (was v3.800.37). Inputs, secrets, and job wiring are unchanged—only the reusable workflow ref tags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f29f01f34751ecf2dd6e4647373201774fb1087. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->